### PR TITLE
代码注释错误

### DIFF
--- a/ChatKit-OC/Example/LCChatKitExample.h
+++ b/ChatKit-OC/Example/LCChatKitExample.h
@@ -44,7 +44,7 @@
 /*!
  *  入口胶水函数：登入入口函数
  *
- *  用户即将退出登录时调用
+ *  用户登录时调用
  */
 + (void)invokeThisMethodAfterLoginSuccessWithClientId:(NSString *)clientId success:(LCCKVoidBlock)success failed:(LCCKErrorBlock)failed;
 /*!


### PR DESCRIPTION
如题,`LCChatKitExample.h`中的`入口胶水函数：登入入口函数`,注释有个小错误.
现在的说明是`用户即将退出登录时调用`，应修改为`用户登录时调用`.