### PR TITLE
会话缓存，变量命名修改

### DIFF
--- a/ChatKit/Class/Module/ConversationList/View/LCCKConversationListCell.m
+++ b/ChatKit/Class/Module/ConversationList/View/LCCKConversationListCell.m
@@ -183,7 +183,8 @@ CGFloat const LCCKConversationListCellDefaultHeight = 61; //LCCKImageSize + LCCK
 - (void)prepareForReuse {
     [super prepareForReuse];
     self.badgeView.badgeText = nil;
-    self.badgeView = nil;
+// 长列表下会引起badgeView频繁创建和销毁，导致卡顿
+//    self.badgeView = nil;
     self.litteBadgeView.hidden = YES;
     self.messageTextLabel.text = nil;
     self.timestampLabel.text = nil;


### PR DESCRIPTION
* 将会话缓存在内存中，减少数据库查询；
* 修改变量命名；
* LCCKConversationListCell中**prepareForReuse**时避免销毁**badgeView**。
