### PR TITLE
 会话缓存，变量名修改

### DIFF
--- a/ChatKit/Class/Module/ConversationList/View/LCCKConversationListCell.m
+++ b/ChatKit/Class/Module/ConversationList/View/LCCKConversationListCell.m
@@ -183,7 +183,8 @@ CGFloat const LCCKConversationListCellDefaultHeight = 61; //LCCKImageSize + LCCK
 - (void)prepareForReuse {
     [super prepareForReuse];
     self.badgeView.badgeText = nil;
-    self.badgeView = nil;
+// 长列表下会引起badgeView频繁创建和销毁，导致卡顿
+//    self.badgeView = nil;
     self.litteBadgeView.hidden = YES;
     self.messageTextLabel.text = nil;
     self.timestampLabel.text = nil;

--- a/ChatKit/Class/Tool/Service/LCCKConversationService.m
+++ b/ChatKit/Class/Tool/Service/LCCKConversationService.m
@@ -409,7 +409,7 @@ NSString *const LCCKConversationServiceErrorDomain = @"LCCKConversationServiceEr
 }
 
 - (NSArray *)allRecentConversations {
-    NSMutableArray *conversations = [self.conversationDictionary allValues];
+    NSArray *conversations = [self.conversationDictionary allValues];
     return conversations;
 }
 


### PR DESCRIPTION
* 缓存会话，减少查询数据库；
* 修改变量命名；
* **LCCKConversationListCell**中调用**prepareForReuse**时，避免销毁**badgeView**；
* 修正返回值不一致的问题。