### PR TITLE
modify updateRecentConversation

### DIFF
--- a/ChatKit/Class/Tool/Service/LCCKConversationService.m
+++ b/ChatKit/Class/Tool/Service/LCCKConversationService.m
@@ -424,6 +424,7 @@ NSString *const LCCKConversationServiceErrorDomain = @"LCCKConversationServiceEr
             conversation.lcck_unreadCount = cachedConversation.lcck_unreadCount;
             conversation.lcck_draft = [cachedConversation.lcck_draft copy];
             conversation.lcck_mentioned = cachedConversation.lcck_mentioned;
+            [self.conversationDictionary setObject:conversation forKey:conversation.conversationId];
         }
     }
     dispatch_async(self.sqliteQueue, ^{

--- a/ChatKit/Class/Tool/Service/LCCKConversationService.m
+++ b/ChatKit/Class/Tool/Service/LCCKConversationService.m
@@ -418,13 +418,23 @@ NSString *const LCCKConversationServiceErrorDomain = @"LCCKConversationServiceEr
 }
 
 - (void)updateRecentConversation:(NSArray *)conversations shouldRefreshWhenFinished:(BOOL)shouldRefreshWhenFinished {
-    [self.databaseQueue inDatabase:^(FMDatabase *db) {
-        [db beginTransaction];
-        for (AVIMConversation *conversation in conversations) {
-            [db executeUpdate:LCCKConversationTableUpdateDataSQL, [self dataFromConversation:conversation], conversation.conversationId];
+    for (AVIMConversation *conversation in conversations) {
+        AVIMConversation *cachedConversation = [self.conversationDictionary objectForKey:conversation.conversationId];
+        if (cachedConversation) {
+            conversation.lcck_unreadCount = cachedConversation.lcck_unreadCount;
+            conversation.lcck_draft = [cachedConversation.lcck_draft copy];
+            conversation.lcck_mentioned = cachedConversation.lcck_mentioned;
         }
-        [db commit];
-    }];
+    }
+    dispatch_async(self.sqliteQueue, ^{
+        [self.databaseQueue inDatabase:^(FMDatabase *db) {
+            [db beginTransaction];
+            for (AVIMConversation *conversation in conversations) {
+                [db executeUpdate:LCCKConversationTableUpdateDataSQL, [self dataFromConversation:conversation], conversation.conversationId];
+            }
+            [db commit];
+        }];
+    });
     if (shouldRefreshWhenFinished) {
         [[NSNotificationCenter defaultCenter] postNotificationName:LCCKNotificationConversationListDataSourceUpdated object:self];
     }


### PR DESCRIPTION
执行updateRecentConversation时，保持缓存与数据库一致。
将已缓存会话的草稿，未读数及mention状态复制给新的会话，然后在sqliteQueue中异步更新数据库。