### PR TITLE
修复联系人无法查询bug

### DIFF
--- a/ChatKit/Class/Module/ContactList/Controller/LCCKContactListViewController.m
+++ b/ChatKit/Class/Module/ContactList/Controller/LCCKContactListViewController.m
@@ -612,8 +612,7 @@ static NSString *const LCCKContactListViewControllerIdentifier = @"LCCKContactLi
 
 - (NSDictionary *)searchSections {
     if (!_searchSections) {
-        NSSet *set = [[NSSet alloc] init];
-        [set setByAddingObjectsFromArray:self.searchContacts];
+        NSSet *set = [NSSet setWithArray:self.searchContacts];
         _searchSections = [self sortedSectionForUserNames:[self contactsFromContactsOrUserIds:set userIds:self.searchUserIds]];
     }
     return _searchSections;


### PR DESCRIPTION
NSSet是不可变的，调用[set
setByAddingObjectsFromArray:self.searchContacts]会返回新的NSSet