### PR TITLE
解决程序在Xcode8编译运行iOS10的时候，在弹出键盘和表情互相切换时，切换动画不正常..

### DIFF
--- a/ChatKit/Class/Module/Conversation/Controller/LCCKConversationViewController.m
+++ b/ChatKit/Class/Module/Conversation/Controller/LCCKConversationViewController.m
@@ -756,7 +756,7 @@ NSString *const LCCKConversationViewControllerErrorDomain = @"LCCKConversationVi
 
 - (void)chatBarFrameDidChange:(LCCKChatBar *)chatBar shouldScrollToBottom:(BOOL)shouldScrollToBottom {
     [UIView animateWithDuration:LCCKAnimateDuration animations:^{
-        [self.tableView layoutIfNeeded];
+        [self.tableView.superview layoutIfNeeded];
         self.allowScrollToBottom = shouldScrollToBottom;
         [self scrollToBottomAnimated:NO];
     } completion:nil];

--- a/ChatKit/Class/Module/Conversation/View/ChatBar/LCCKChatBar.m
+++ b/ChatKit/Class/Module/Conversation/View/ChatBar/LCCKChatBar.m
@@ -106,6 +106,18 @@ NSString *const kLCCKBatchDeleteTextSuffix = @"kLCCKBatchDeleteTextSuffix";
     [self.voiceRecordButton mas_makeConstraints:^(MASConstraintMaker *make) {
         make.edges.mas_equalTo(self.textView).insets(UIEdgeInsetsMake(voiceRecordButtoInsets, voiceRecordButtoInsets, voiceRecordButtoInsets, voiceRecordButtoInsets));
     }];
+    
+    [self.faceView mas_makeConstraints:^(MASConstraintMaker *make) {
+        make.width.and.left.mas_equalTo(self);
+        make.height.mas_equalTo(kFunctionViewHeight);
+        make.top.mas_equalTo(self.mas_bottom);
+    }];
+    
+    [self.moreView mas_makeConstraints:^(MASConstraintMaker *make) {
+        make.width.and.left.mas_equalTo(self);
+        make.height.mas_equalTo(kFunctionViewHeight);
+        make.top.mas_equalTo(self.mas_bottom);
+    }];
 }
 
 - (void)dealloc {
@@ -458,6 +470,8 @@ NSString *const kLCCKBatchDeleteTextSuffix = @"kLCCKBatchDeleteTextSuffix";
     self.oldTextViewHeight = kLCCKChatBarTextViewFrameMinHeight;
     self.allowTextViewContentOffset = YES;
     self.MP3 = [[Mp3Recorder alloc] initWithDelegate:self];
+    [self faceView];
+    [self moreView];
     [self addSubview:self.inputBarBackgroundView];
     
     [self.inputBarBackgroundView addSubview:self.voiceButton];
@@ -577,19 +591,11 @@ NSString *const kLCCKBatchDeleteTextSuffix = @"kLCCKBatchDeleteTextSuffix";
 
 - (void)showFaceView:(BOOL)show {
     if (show) {
-        [self faceView];
-        [self.faceView mas_makeConstraints:^(MASConstraintMaker *make) {
-            make.width.and.left.mas_equalTo(self);
-            make.height.mas_equalTo(kFunctionViewHeight);
-            // hide blow screen
-            make.top.mas_equalTo(self.superview.mas_bottom);
-        }];
-        [self.faceView layoutIfNeeded];
-        
-        [self.faceView mas_updateConstraints:^(MASConstraintMaker *make) {
-            make.top.mas_equalTo(self.superview.mas_bottom).offset(-kFunctionViewHeight);
-        }];
+        self.faceView.hidden = NO;
         [UIView animateWithDuration:LCCKAnimateDuration animations:^{
+            [self.faceView mas_updateConstraints:^(MASConstraintMaker *make) {
+                make.top.mas_equalTo(self.superview.mas_bottom).offset(-kFunctionViewHeight);
+            }];
             [self.faceView layoutIfNeeded];
         } completion:nil];
         
@@ -597,7 +603,13 @@ NSString *const kLCCKBatchDeleteTextSuffix = @"kLCCKBatchDeleteTextSuffix";
             make.top.mas_equalTo(self.inputBarBackgroundView.mas_bottom);
         }];
     } else if (self.faceView.superview) {
-        [self.faceView removeFromSuperview];
+        self.faceView.hidden = YES;
+        [self.faceView mas_remakeConstraints:^(MASConstraintMaker *make) {
+            make.width.and.left.mas_equalTo(self);
+            make.height.mas_equalTo(kFunctionViewHeight);
+            make.top.mas_equalTo(self.mas_bottom);
+        }];
+        [self.faceView layoutIfNeeded];
     }
 }
 
@@ -607,20 +619,11 @@ NSString *const kLCCKBatchDeleteTextSuffix = @"kLCCKBatchDeleteTextSuffix";
  */
 - (void)showMoreView:(BOOL)show {
     if (show) {
-        [self moreView];
-        [self.moreView mas_makeConstraints:^(MASConstraintMaker *make) {
-            make.width.and.left.mas_equalTo(self);
-            make.height.mas_equalTo(kFunctionViewHeight);
-            // hide blow screen
-            make.top.mas_equalTo(self.superview.mas_bottom);
-        }];
-        [self.moreView layoutIfNeeded];
-        
-        [self.moreView mas_updateConstraints:^(MASConstraintMaker *make) {
-            make.top.mas_equalTo(self.superview.mas_bottom).offset(-kFunctionViewHeight);
-        }];
-        
+        self.moreView.hidden = NO;
         [UIView animateWithDuration:LCCKAnimateDuration animations:^{
+            [self.moreView mas_updateConstraints:^(MASConstraintMaker *make) {
+                make.top.mas_equalTo(self.superview.mas_bottom).offset(-kFunctionViewHeight);
+            }];
             [self.moreView layoutIfNeeded];
         } completion:nil];
         
@@ -628,7 +631,13 @@ NSString *const kLCCKBatchDeleteTextSuffix = @"kLCCKBatchDeleteTextSuffix";
             make.top.mas_equalTo(self.inputBarBackgroundView.mas_bottom);
         }];
     } else if (self.moreView.superview) {
-        [self.moreView removeFromSuperview];
+        self.moreView.hidden = YES;
+        [self.moreView mas_remakeConstraints:^(MASConstraintMaker *make) {
+            make.width.and.left.mas_equalTo(self);
+            make.height.mas_equalTo(kFunctionViewHeight);
+            make.top.mas_equalTo(self.mas_bottom);
+        }];
+        [self.moreView layoutIfNeeded];
     }
 }
 
@@ -698,6 +707,7 @@ NSString *const kLCCKBatchDeleteTextSuffix = @"kLCCKBatchDeleteTextSuffix";
     if (!_faceView) {
         LCCKChatFaceView *faceView = [[LCCKChatFaceView alloc] init];
         faceView.delegate = self;
+        faceView.hidden = YES;
         faceView.backgroundColor = self.backgroundColor;
         [self addSubview:(_faceView = faceView)];
     }
@@ -708,6 +718,7 @@ NSString *const kLCCKBatchDeleteTextSuffix = @"kLCCKBatchDeleteTextSuffix";
     if (!_moreView) {
         LCCKChatMoreView *moreView = [[LCCKChatMoreView alloc] init];
         moreView.inputViewRef = self;
+        moreView.hidden = YES;
         [self addSubview:(_moreView = moreView)];
     }
     return _moreView;


### PR DESCRIPTION
问题如下图所示，是在模拟器slow animation下截图：三个图分别为1.从键盘切换到表情 2.从表情切换到键盘 3.从键盘到键盘消失。
![default](https://cloud.githubusercontent.com/assets/8705722/20778984/9577d198-b7ac-11e6-8eba-53f7f1965670.png)
![default](https://cloud.githubusercontent.com/assets/8705722/20778983/953547ec-b7ac-11e6-92f1-84d422b4a64e.png)
![default](https://cloud.githubusercontent.com/assets/8705722/20778985/96a5ee42-b7ac-11e6-85dd-d4347ac935ba.png)

