### PR TITLE
聊天界面使用fd进行cell高度计算通过key值缓存

### DIFF
--- a/ChatKit/Class/Module/Conversation/Model/LCCKConversationViewModel.m
+++ b/ChatKit/Class/Module/Conversation/Model/LCCKConversationViewModel.m
@@ -92,9 +92,10 @@
 }
 
 - (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath {
-    id message = self.dataArray[indexPath.row];
+    LCCKMessage *message = self.dataArray[indexPath.row];
     NSString *identifier = [LCCKCellIdentifierFactory cellIdentifierForMessageConfiguration:message conversationType:[self.parentConversationViewController getConversationIfExists].lcck_type];
-    return [tableView fd_heightForCellWithIdentifier:identifier cacheByIndexPath:indexPath configuration:^(LCCKChatMessageCell *cell) {
+    NSString *cacheKey = [NSString stringWithFormat:@"%f",message.timestamp];
+    return [tableView fd_heightForCellWithIdentifier:identifier cacheByKey:cacheKey configuration:^(LCCKChatMessageCell *cell) {
         [cell configureCellWithData:message];
     }];
 }


### PR DESCRIPTION
聊天界面拉取历史消息，如果使用cacheByIndexPath做缓存，会因为数据源都是从头部插入，使已经存在的message的indexPath都发生变化，在tableview reloadData的时候全部重新做了一次高度计算；效果表现在：在聊天界面存在很多聊天记录，不停下拉，越后面加载的时候就越长，基本200条后，时间会有2秒多了...通过cacheByKey能解决这个问题，每次下拉时间都在0.2秒左右。
注：cacheKey，我是随便找的一个唯一标识，这个可能需要修改
