### PR TITLE
Fix #273: make sure preloading message in LCCKConversationViewModel t…

### DIFF
--- a/ChatKit/Class/Module/Conversation/Model/LCCKConversationViewModel.m
+++ b/ChatKit/Class/Module/Conversation/Model/LCCKConversationViewModel.m
@@ -47,7 +47,12 @@
 #import "CYLDeallocBlockExecutor.h"
 #endif
 
-@interface LCCKConversationViewModel ()
+#define LCCKLock() dispatch_semaphore_wait(self->_lcck_lock, DISPATCH_TIME_FOREVER)
+#define LCCKUnlock() dispatch_semaphore_signal(self->_lcck_lock)
+
+@interface LCCKConversationViewModel () {
+    dispatch_semaphore_t _lcck_lock;
+}
 
 @property (nonatomic, weak) LCCKConversationViewController *parentConversationViewController;
 @property (nonatomic, strong) NSMutableArray *dataArray;
@@ -65,6 +70,7 @@
 
 - (instancetype)initWithParentViewController:(LCCKConversationViewController *)parentConversationViewController {
     if (self = [super init]) {
+        _lcck_lock = dispatch_semaphore_create(1);
         _dataArray = [NSMutableArray array];
         _avimTypedMessage = [NSMutableArray array];
         self.parentConversationViewController = parentConversationViewController;
@@ -230,9 +236,9 @@
 
 - (void)appendMessagesToDataArrayTrailing:(NSArray *)messages {
     if (messages.count > 0) {
-        @synchronized (self) {
-            [self.dataArray addObjectsFromArray:messages];
-        }
+        LCCKLock();
+        [self.dataArray addObjectsFromArray:messages];
+        LCCKUnlock();
     }
 }
 
@@ -591,6 +597,7 @@ fromTimestamp     |    toDate   |                |  上次上拉刷新顶端，�
     NSUInteger newLastMessageCout = self.dataArray.count;
     NSIndexPath *indexPath = [NSIndexPath indexPathForRow:self.dataArray.count - 1 inSection:0];
     [self.delegate messageSendStateChanged:LCCKMessageSendStateSending withProgress:0.0f forIndex:indexPath.row];
+    LCCKLock();
     NSMutableArray *indexPaths = [NSMutableArray arrayWithObject:indexPath];
     NSUInteger additionItemsCount = newLastMessageCout - oldLastMessageCount;
     if (additionItemsCount > 1) {
@@ -601,6 +608,7 @@ fromTimestamp     |    toDate   |                |  上次上拉刷新顶端，�
     }
     dispatch_async(dispatch_get_main_queue(),^{
         [self.parentConversationViewController.tableView insertRowsAtIndexPaths:[indexPaths copy] withRowAnimation:UITableViewRowAnimationNone];
+        LCCKUnlock();
         [self.parentConversationViewController scrollToBottomAnimated:YES];
         !callback ?: callback();
     });


### PR DESCRIPTION
## My issue:
<!--- Please describe which issue do you want to fix. -->

修复了 #273  在对话双方大量的消息发送的时候，偶尔会发生闪退，原因是这样的，在ViewModel执行
`insertRowsAtIndexPaths:withRowAnimation:`的时候，有可能发生dataSource的插入操作，这样就会导致抛出异常，所以仅仅在dataSource执行append操作的时候加锁是不够的。在tableView进行insert操作的时候也需要上锁。


## What I have done:

我给ConversationViewModel添加了一个信号锁：`_lcck_lock`

并且定义了两个便捷操作的宏:

```
#define LCCKLock() dispatch_semaphore_wait(lcck_lock, DISPATCH_TIME_FOREVER)
#define LCCKUnlock() dispatch_semaphore_signal(lcck_lock)
```

然后用这个信号所替代了之前的`@synchronized`，于此同时我也在每次tableView执行插入操作的时候上锁，保证indexSections是预料之中的。