### PR TITLE
Associate lcck message with raw message

### DIFF
--- a/ChatKit/Class/Model/LCCKMessage.h
+++ b/ChatKit/Class/Model/LCCKMessage.h
@@ -14,6 +14,8 @@
 
 @interface LCCKMessage : NSObject <NSCoding, NSCopying, LCCKMessageDelegate>
 
+@property (nonatomic, strong) AVIMMessage *message;
+
 @property (nonatomic, copy, readonly) NSString *text;
 @property (nonatomic, copy, readonly) NSString *systemText;
 @property (nonatomic, strong, readwrite) UIImage *photo;

--- a/ChatKit/Class/Model/LCCKMessage.m
+++ b/ChatKit/Class/Model/LCCKMessage.m
@@ -364,6 +364,7 @@
         lcckMessage.ownerType = LCCKMessageOwnerTypeOther;
     }
     lcckMessage.sendStatus = (LCCKMessageSendState)message.status;
+    lcckMessage.message = message;
 
     return lcckMessage;
 }

--- a/ChatKit/Class/Module/Conversation/Model/LCCKConversationViewModel.m
+++ b/ChatKit/Class/Module/Conversation/Model/LCCKConversationViewModel.m
@@ -483,6 +483,7 @@ fromTimestamp     |    toDate   |                |  上次上拉刷新顶端，�
         message.sender = sender;
         message.ownerType = LCCKMessageOwnerTypeSelf;
         avimTypedMessage = [AVIMTypedMessage lcck_messageWithLCCKMessage:message];
+        message.message = avimTypedMessage;
     } else {
         avimTypedMessage = aMessage;
     }


### PR DESCRIPTION
让 LCCKMessage 关联 AVMessage，以保证在 ChatKit 中能获取消息的全部信息。