### PR TITLE
Extends LCCKConversationViewController causes load bundle to fail

### DIFF
--- a/ChatKit/Class/Tool/LCCKConstants.h
+++ b/ChatKit/Class/Tool/LCCKConstants.h
@@ -48,7 +48,7 @@ static NSString *const LCCKBadgeTextForNumberGreaterThanLimit = @"···";
 
 #ifndef LCCKLocalizedStrings
 #define LCCKLocalizedStrings(key) \
-    NSLocalizedStringFromTableInBundle(key, @"LCChatKitString", [NSBundle lcck_bundleForName:@"Other" class:[self class]], nil)
+    NSLocalizedStringFromTableInBundle(key, @"LCChatKitString", [NSBundle lcck_bundleForName:@"Other" class:[LCChatKit class]], nil)
 #endif
 
 


### PR DESCRIPTION
## My issue:
<!--- Please describe which issue do you want to fix. -->

Extends LCCKConversationViewController causes load bundle to fail

## What I have done:
